### PR TITLE
fix: update git-flow feature purge logic for develop branch handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Available targets:
   gitflow/feature/finish/%            Git-Flow feature finish (manual), this receives the following call pattern: make gitflow/feature/manual/finish:<feature_name>
   gitflow/feature/publish             Git-Flow feature publish
   gitflow/feature/publish/%           Git-Flow feature publish, this receives the following call pattern: make gitflow/feature/publish:<feature_name>
-  gitflow/feature/purge-no-develop/%  Git-Flow feature purge, this receives the following call pattern: make gitflow/feature/purge-no-develop:<feature_name> # This will not checkout develop branch
   gitflow/feature/purge/%             Git-Flow feature purge, this receives the following call pattern: make gitflow/feature/purge:<feature_name>
   gitflow/feature/start-no-develop/%  Git-Flow feature start for main-branch development, this receives the following call pattern: make gitflow/feature/start-no-develop:<feature_name>
   gitflow/feature/start/%             Git-Flow feature start, this receives the following call pattern: make gitflow/feature/start:<feature_name>

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -20,7 +20,6 @@ Available targets:
   gitflow/feature/finish/%            Git-Flow feature finish (manual), this receives the following call pattern: make gitflow/feature/manual/finish:<feature_name>
   gitflow/feature/publish             Git-Flow feature publish
   gitflow/feature/publish/%           Git-Flow feature publish, this receives the following call pattern: make gitflow/feature/publish:<feature_name>
-  gitflow/feature/purge-no-develop/%  Git-Flow feature purge, this receives the following call pattern: make gitflow/feature/purge-no-develop:<feature_name> # This will not checkout develop branch
   gitflow/feature/purge/%             Git-Flow feature purge, this receives the following call pattern: make gitflow/feature/purge:<feature_name>
   gitflow/feature/start-no-develop/%  Git-Flow feature start for main-branch development, this receives the following call pattern: make gitflow/feature/start-no-develop:<feature_name>
   gitflow/feature/start/%             Git-Flow feature start, this receives the following call pattern: make gitflow/feature/start:<feature_name>

--- a/modules/gitflow/Makefile
+++ b/modules/gitflow/Makefile
@@ -130,20 +130,18 @@ else
 endif
 
 ## Git-Flow feature purge, this receives the following call pattern: make gitflow/feature/purge:<feature_name>
-gitflow/feature/purge/%: gitflow/co/develop
+gitflow/feature/purge/%: gitflow/co/main
 	$(call assert-set,GIT)
 	$(eval FEAT_NAME := $(subst gitflow/feature/purge/,,$@))
 	# Assumes that feature branch is prefixed with feature/
 	@$(GIT) branch -D feature/$(FEAT_NAME)
 	@$(GIT) push origin -d feature/$(FEAT_NAME)
-
-## Git-Flow feature purge, this receives the following call pattern: make gitflow/feature/purge-no-develop:<feature_name> # This will not checkout develop branch
-gitflow/feature/purge-no-develop/%: gitflow/co/main
-	$(call assert-set,GIT)
-	$(eval FEAT_NAME := $(subst gitflow/feature/purge-no-develop/,,$@))
-	# Assumes that feature branch is prefixed with feature/
-	@$(GIT) branch -D feature/$(FEAT_NAME)
-	@$(GIT) push origin -d feature/$(FEAT_NAME)
+	# Check if develop branch exists, if exists checkout develop
+	$(eval DEVELOP_BRANCH := $(shell $(GIT) branch -r --format "%(refname:short)" | awk '/origin/ && ($$0 ~ /origin\/develop/) {sub("origin/", ""); print}'))
+ifeq ($(DEVELOP_BRANCH),develop)
+	@$(GIT) checkout develop
+	@$(GIT) pull origin develop
+endif
 
 ## Git-Flow feature finish (automatic via PR), this receives the following call pattern: make gitflow/feature/finish-no-develop must be on a feature branch and will generate a PR against MAIN branch instead of develop, this is useful for hotfixes or features that need to be merged directly into main without going through develop branch
 gitflow/feature/finish-no-develop: gitflow/deps


### PR DESCRIPTION
## Summary

- Switch `gitflow/feature/purge/%` dependency from `gitflow/co/develop` to `gitflow/co/main`.
- Add conditional logic to check if the `develop` branch exists; if present, checkout and pull updates from `develop`.
- Remove redundant `gitflow/feature/purge-no-develop/%` target to simplify Makefile.

+semver: fix