### PR TITLE
docs: update README template with product links and remove empty sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,21 +237,19 @@ File a GitHub [issue](https://github.com/cloudopsworks/tronador/issues), send us
 
 
 ## DevOps Tools
-[]()
+[Our Products](https://cloudopsworks.co/products/)
+[CI/CD Blueprint](https://cloudopsworks.co/cicd-blueprint/)
+[Open Source](https://cloudopsworks.co/open-source/)
+
 ## Slack Community
 
 
 ## Newsletter
-
-## Office Hours
-
-## Contributing
+[Resources Directory](https://cloudopsworks.co/resources/)
 
 ### Bug Reports & Feature Requests
 
 Please use the [issue tracker](https://github.com/cloudopsworks/tronador/issues) to report any bugs or file feature requests.
-
-### Developing
 
 
 

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -127,21 +127,19 @@ File a GitHub [issue]({{ printf "https://github.com/%s/issues" (ds "config").git
 
 
 ## DevOps Tools
-[]()
+[Our Products](https://cloudopsworks.co/products/)
+[CI/CD Blueprint](https://cloudopsworks.co/cicd-blueprint/)
+[Open Source](https://cloudopsworks.co/open-source/)
+
 ## Slack Community
 
 
 ## Newsletter
-
-## Office Hours
-
-## Contributing
+[Resources Directory](https://cloudopsworks.co/resources/)
 
 ### Bug Reports & Feature Requests
 
 Please use the [issue tracker]({{ printf "https://github.com/%s/issues" (ds "config").github_repo}}) to report any bugs or file feature requests.
-
-### Developing
 
 
 {{ if has (ds "config") "copyrights" }}


### PR DESCRIPTION
## Summary

- Replace empty DevOps Tools placeholder with real product links (cloudopsworks.co)
- Add CI/CD Blueprint and Open Source links
- Replace empty Newsletter section with Resources Directory link
- Remove empty Office Hours, Contributing, and Developing sections

+semver: patch